### PR TITLE
[RESPONSIVENESS] - Improve styles for Desktop and Mobile.

### DIFF
--- a/src/views/games/GameView.vue
+++ b/src/views/games/GameView.vue
@@ -17,7 +17,7 @@
         />
       </div>
       <div>
-        <Messages :singleElement="true" @send="sendChat" :messages="messages" />
+        <Messages @send="sendChat" :messages="messages" />
       </div>
     </div>
   </v-container>

--- a/src/views/games/GameView.vue
+++ b/src/views/games/GameView.vue
@@ -1,25 +1,50 @@
 <template>
   <v-container fluid class="pa-2">
-    <div class="pa-2 mb-2 container-display">
-      <div class="game-div">
-        <div class="game-grid pb-2">
-          <div>Game {{ game.gameId }}</div>
-          <div>{{ game.map.minesLeft }} mines left</div>
-        </div>
-        <PlayerView :playerData="game.playerData[0]" />
-        <PlayerView :playerData="game.playerData[1]" />
-      </div>
-      <div>
-        <MapView
-          :onClick="onClick"
-          :game="game"
-          :highlightWeapon="highlightWeapon"
-        />
-      </div>
-      <div>
-        <Messages @send="sendChat" :messages="messages" />
-      </div>
-    </div>
+    <v-layout map-flex align-center justify-center column fill-height>
+      <v-layout
+        class="fill-height"
+        map-flex
+        align-space-around
+        justify-center
+        :fill-height="$vuetify.breakpoint.lgAndUp"
+        :column="$vuetify.breakpoint.mdAndDown"
+      >
+        <v-flex xs12 lg3 xl4>
+          <v-layout
+            class="fill-height"
+            align-center
+            justify-center
+            column
+            :fill-height="$vuetify.breakpoint.lgAndUp"
+            style="height: 100%"
+          >
+            <div class="mb-2">
+              <span>Game {{ game.gameId }}</span>
+              <span> / </span>
+              <b>{{ game.map.minesLeft }} mines left</b>
+            </div>
+            <PlayerView :playerData="game.playerData[0]" />
+            <PlayerView class="my-2" :playerData="game.playerData[1]" />
+          </v-layout>
+        </v-flex>
+        <v-flex xs12 lg6 xl6 map-flex>
+          <MapView
+            class="px-1"
+            :onClick="onClick"
+            :game="game"
+            :highlightWeapon="highlightWeapon"
+          />
+        </v-flex>
+        <v-flex xs12 lg3 xl2>
+          <Messages
+            class="px-1"
+            @send="sendChat"
+            :messages="messages"
+            :singleElement="true"
+          />
+        </v-flex>
+      </v-layout>
+    </v-layout>
   </v-container>
 </template>
 
@@ -65,20 +90,11 @@ export default {
 };
 </script>
 <style>
-.game-grid {
-  display: grid;
-  grid-template-columns: 60% 40%;
+.container {
+  height: 100%;
 }
-
-@media (min-width: 768px) {
-  .container-display {
-    display: grid;
-    grid-template-columns: 30% 40% 25%;
-    gap: 30px;
-  }
-
-  .game-div {
-    align-self: center;
-  }
+.map-flex {
+  width: 100%;
+  height: 100%;
 }
 </style>

--- a/src/views/games/GameView.vue
+++ b/src/views/games/GameView.vue
@@ -1,51 +1,28 @@
 <template>
-  <div class="map-flex">
-    <v-container fluid>
-      <v-layout map-flex align-center justify-center column fill-height>
-        <h1>Game {{ game.gameId }}</h1>
-        <v-layout
-          class="fill-height"
-          map-flex
-          align-space-around
-          justify-center
-          :fill-height="$vuetify.breakpoint.lgAndUp"
-          :column="$vuetify.breakpoint.mdAndDown"
-        >
-          <v-flex xs12 lg3 xl4>
-            <v-layout
-              class="fill-height"
-              align-center
-              justify-center
-              column
-              :fill-height="$vuetify.breakpoint.lgAndUp"
-              style="height: 100%"
-            >
-              <PlayerView :playerData="game.playerData[0]" />
-              <h1 class="mines-remaining">
-                {{ game.map.minesLeft }} mines left
-              </h1>
-              <PlayerView :playerData="game.playerData[1]" />
-            </v-layout>
-          </v-flex>
-          <v-flex xs12 lg6 xl6 map-flex>
-            <MapView
-              :onClick="onClick"
-              :game="game"
-              :highlightWeapon="highlightWeapon"
-            />
-          </v-flex>
-          <v-flex xs12 lg3 xl2>
-            <Messages
-              :singleElement="true"
-              @send="sendChat"
-              :messages="messages"
-            />
-          </v-flex>
-        </v-layout>
-      </v-layout>
-    </v-container>
-  </div>
+  <v-container fluid class="pa-2">
+    <div class="pa-2 mb-2 container-display">
+      <div class="game-div">
+        <div class="game-grid pb-2">
+          <div>Game {{ game.gameId }}</div>
+          <div>{{ game.map.minesLeft }} mines left</div>
+        </div>
+        <PlayerView :playerData="game.playerData[0]" />
+        <PlayerView :playerData="game.playerData[1]" />
+      </div>
+      <div>
+        <MapView
+          :onClick="onClick"
+          :game="game"
+          :highlightWeapon="highlightWeapon"
+        />
+      </div>
+      <div>
+        <Messages :singleElement="true" @send="sendChat" :messages="messages" />
+      </div>
+    </div>
+  </v-container>
 </template>
+
 <script>
 import PlayerView from "./PlayerView";
 import MapView from "./MapView";
@@ -67,15 +44,15 @@ export default {
       this.$store.dispatch("games/makeMove", {
         game: this.game,
         weapon: this.highlightWeapon,
-        field: field
+        field: field,
       });
-    }
+    },
   },
   computed: {
     ...mapState("lobby", {
       messages(state) {
         return state.ingameMessages;
-      }
+      },
     }),
     highlightWeapon() {
       let playerIndex = this.game.map.currentPlayer.index;
@@ -83,19 +60,25 @@ export default {
       let weapons = this.game.map.currentPlayer.weapons;
       let weapon = weapons.toArray()[playerData.selectedWeapon];
       return weapon;
-    }
-  }
+    },
+  },
 };
 </script>
 <style>
-.mines-remaining {
-  margin: 20px 0 20px 0;
+.game-grid {
+  display: grid;
+  grid-template-columns: 60% 40%;
 }
-.container {
-  height: 100%;
-}
-.map-flex {
-  width: 100%;
-  height: 100%;
+
+@media (min-width: 768px) {
+  .container-display {
+    display: grid;
+    grid-template-columns: 30% 40% 25%;
+    gap: 30px;
+  }
+
+  .game-div {
+    align-self: center;
+  }
 }
 </style>

--- a/src/views/games/MapView.vue
+++ b/src/views/games/MapView.vue
@@ -178,6 +178,12 @@ This class is in charge of two things:
   height: 80%;
 }
 
+@media (max-width: 767px) {
+  .map-rect {
+    margin-bottom: 1rem;
+  }
+}
+
 /*
 Build a square that map will be relative to.
 I've not implemented the JS to do this.

--- a/src/views/games/MapView.vue
+++ b/src/views/games/MapView.vue
@@ -1,33 +1,28 @@
 <template>
   <div class="map-rect">
     <resize-observer @notify="updateMapRect" />
-    <div
-      class="map-square"
-      :style="{ height: mapRect + 'px', width: mapRect + 'px' }"
-    >
-      <div class="map-reset">
-        <div class="map">
-          <div class="fields fields-bg field-views">
-            <template v-for="y in game.map.height">
-              <FieldView
-                v-for="x in game.map.width"
-                :key="'field' + y + '-' + x"
-                :onClick="clickedField"
-                :highlighted="highlightedFields[y - 1][x - 1]"
-                :onHighlight="onHighlight"
-                :field="fields[y - 1][x - 1]"
-              />
-            </template>
-            <div
-              v-for="move in nonNullLastMoves"
-              class="selector"
-              :key="move.player.index"
-              :class="'selector-' + move.player.index"
-              v-bind:style="{
-                gridArea: move.field.y + 1 + '/' + (move.field.x + 1)
-              }"
+    <div class="map-reset">
+      <div class="map">
+        <div class="fields fields-bg field-views">
+          <template v-for="y in game.map.height">
+            <FieldView
+              v-for="x in game.map.width"
+              :key="'field' + y + '-' + x"
+              :onClick="clickedField"
+              :highlighted="highlightedFields[y - 1][x - 1]"
+              :onHighlight="onHighlight"
+              :field="fields[y - 1][x - 1]"
             />
-          </div>
+          </template>
+          <div
+            v-for="move in nonNullLastMoves"
+            class="selector"
+            :key="move.player.index"
+            :class="'selector-' + move.player.index"
+            v-bind:style="{
+              gridArea: move.field.y + 1 + '/' + (move.field.x + 1),
+            }"
+          />
         </div>
       </div>
     </div>
@@ -54,7 +49,7 @@ export default {
   data() {
     return {
       highlightedField: null,
-      mapRect: 280
+      mapRect: 280,
     };
   },
   mounted() {
@@ -73,13 +68,13 @@ export default {
       if (this.onClick) {
         this.onClick(field);
       }
-    }
+    },
   },
   computed: {
     nonNullLastMoves() {
       return this.game.playerData
-        .map(pl => pl.lastMove)
-        .filter(move => move !== null);
+        .map((pl) => pl.lastMove)
+        .filter((move) => move !== null);
     },
     fields() {
       console.log("compute fields");
@@ -123,8 +118,8 @@ export default {
         Array.apply(null, Array(this.game.map.width)).map((_, x) => func(x, y))
       );
       return result;
-    }
-  }
+    },
+  },
 };
 </script>
 <style scoped>
@@ -180,14 +175,7 @@ This class is in charge of two things:
 */
 .map-rect {
   width: 100%;
-  height: 100%;
-  min-width: 280px;
-  min-height: 280px;
-  max-width: 100%;
-  max-height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  height: 80%;
 }
 
 /*
@@ -198,10 +186,6 @@ If only there were a way to do this in CSS. :(
 I've asked a question to see if there is a nicer way to do this:
 https://stackoverflow.com/q/54858625
 */
-.map-square {
-  width: 280px; /* map-rect.min */
-  height: 280px; /* map-rect.min */
-}
 
 /*
 The following is using a mix between the following two answers:
@@ -214,19 +198,7 @@ https://stackoverflow.com/a/20117454
   width: 100%;
 }
 
-.map-reset:before {
-  content: "";
-  display: block;
-  padding-top: 100%;
-}
-
 .map {
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
-
   /* normal box settings here */
   height: 100%;
   border: 12px solid #6d5720;

--- a/src/views/games/MapView.vue
+++ b/src/views/games/MapView.vue
@@ -1,28 +1,33 @@
 <template>
   <div class="map-rect">
     <resize-observer @notify="updateMapRect" />
-    <div class="map-reset">
-      <div class="map">
-        <div class="fields fields-bg field-views">
-          <template v-for="y in game.map.height">
-            <FieldView
-              v-for="x in game.map.width"
-              :key="'field' + y + '-' + x"
-              :onClick="clickedField"
-              :highlighted="highlightedFields[y - 1][x - 1]"
-              :onHighlight="onHighlight"
-              :field="fields[y - 1][x - 1]"
+    <div
+      class="map-square"
+      :style="{ height: mapRect + 'px', width: mapRect + 'px' }"
+    >
+      <div class="map-reset">
+        <div class="map">
+          <div class="fields fields-bg field-views">
+            <template v-for="y in game.map.height">
+              <FieldView
+                v-for="x in game.map.width"
+                :key="'field' + y + '-' + x"
+                :onClick="clickedField"
+                :highlighted="highlightedFields[y - 1][x - 1]"
+                :onHighlight="onHighlight"
+                :field="fields[y - 1][x - 1]"
+              />
+            </template>
+            <div
+              v-for="move in nonNullLastMoves"
+              class="selector"
+              :key="move.player.index"
+              :class="'selector-' + move.player.index"
+              v-bind:style="{
+                gridArea: move.field.y + 1 + '/' + (move.field.x + 1),
+              }"
             />
-          </template>
-          <div
-            v-for="move in nonNullLastMoves"
-            class="selector"
-            :key="move.player.index"
-            :class="'selector-' + move.player.index"
-            v-bind:style="{
-              gridArea: move.field.y + 1 + '/' + (move.field.x + 1),
-            }"
-          />
+          </div>
         </div>
       </div>
     </div>
@@ -158,9 +163,6 @@ export default {
   left: 0;
   width: 100%;
   height: 100%;
-}
-
-.fields {
   grid-template-columns: repeat(16, minmax(16px, 1fr));
   grid-template-rows: repeat(16, minmax(16px, 1fr));
 }
@@ -189,7 +191,14 @@ This class is in charge of two things:
 */
 .map-rect {
   width: 100%;
-  height: 80%;
+  height: 100%;
+  min-width: 280px;
+  min-height: 280px;
+  max-width: 100%;
+  max-height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 @media (max-width: 767px) {
@@ -220,8 +229,19 @@ https://stackoverflow.com/a/20117454
 
 .map {
   /* normal box settings here */
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
   height: 100%;
   border: 12px solid #6d5720;
   border-radius: 12px;
+}
+
+.map-reset:before {
+  content: "";
+  display: block;
+  padding-top: 100%;
 }
 </style>

--- a/src/views/games/MapView.vue
+++ b/src/views/games/MapView.vue
@@ -138,6 +138,20 @@ export default {
   border-color: #ff0000;
 }
 
+@media (max-width: 767px) {
+  .selector {
+    border: 2px solid #000000;
+  }
+
+  .selector-0 {
+    border-color: #0000ff;
+  }
+
+  .selector-1 {
+    border-color: #ff0000;
+  }
+}
+
 .fields {
   display: grid;
   top: 0;

--- a/src/views/games/PlayerView.vue
+++ b/src/views/games/PlayerView.vue
@@ -2,21 +2,20 @@
   <v-card dark>
     <v-container
       fluid
-      class="player-view pa-0"
+      class="player-view"
       :class="[isMyTurn ? 'active' : '', 'player' + index]"
     >
       <div class="pa-2 display-grid">
         <div>
           <img
             :src="userPicture"
-            style="border-radius: 50px"
-            width="24px"
-            height="24px"
+            style="border-radius: 50%"
+            class="avatar-img"
             v-if="userPicture"
           />
           <v-icon large v-else>help</v-icon>
-          <span> {{ name }} - {{ score }} </span>
         </div>
+        <div>{{ name }} - {{ score }}</div>
         <div v-if="playerData.controllable">
           <v-btn-toggle v-model="activeWeaponIndex" mandatory>
             <v-btn v-for="(weapon, index) in playerWeapons" :key="index">
@@ -26,7 +25,6 @@
         </div>
       </div>
     </v-container>
-    <div></div>
   </v-card>
 </template>
 <script>
@@ -88,6 +86,7 @@ export default {
   width: 100%;
   margin-bottom: 10px;
   margin-right: 10px;
+  padding: 16px;
 }
 
 .player0 {
@@ -113,6 +112,23 @@ export default {
 
 .display-grid {
   display: grid;
-  grid-template-columns: 60% 40%;
+  grid-template-columns: 15% 50% 40%;
+  align-items: center;
+}
+
+.avatar-img {
+  width: 36px;
+  height: 36px;
+}
+
+@media (max-width: 767px) {
+  .player-view {
+    padding: 0;
+  }
+
+  .avatar-img {
+    width: 24px;
+    height: 24px;
+  }
 }
 </style>

--- a/src/views/games/PlayerView.vue
+++ b/src/views/games/PlayerView.vue
@@ -1,42 +1,32 @@
 <template>
-  <v-card
-    dark
-    class="player-view"
-    :class="[isMyTurn ? 'active' : '', 'player' + index]"
-  >
-    <v-container fluid>
-      <v-layout align-center justify-center column>
-        <v-layout
-          class="container fluid"
-          row
-          align-center
-          justify-space-between
-        >
-          <v-list-tile-avatar>
-            <img
-              :src="userPicture"
-              width="64px"
-              height="64px"
-              v-if="userPicture"
-            />
-            <v-icon large v-else>help</v-icon>
-          </v-list-tile-avatar>
-          <v-list-tile-content>
-            <h1>{{ name }}</h1>
-          </v-list-tile-content>
-          <v-layout align-center justify-end fill-height>
-            <h2>{{ score }}</h2>
-          </v-layout>
-        </v-layout>
-        <v-card-actions v-if="playerData.controllable">
+  <v-card dark>
+    <v-container
+      fluid
+      class="player-view pa-0"
+      :class="[isMyTurn ? 'active' : '', 'player' + index]"
+    >
+      <div class="pa-2 display-grid">
+        <div>
+          <img
+            :src="userPicture"
+            style="border-radius: 50px"
+            width="24px"
+            height="24px"
+            v-if="userPicture"
+          />
+          <v-icon large v-else>help</v-icon>
+          <span> {{ name }} - {{ score }} </span>
+        </div>
+        <div v-if="playerData.controllable">
           <v-btn-toggle v-model="activeWeaponIndex" mandatory>
-            <v-btn v-for="(weapon, index) in playerWeapons" :key="index">{{
-              weaponNames[weapon.key.c]
-            }}</v-btn>
+            <v-btn v-for="(weapon, index) in playerWeapons" :key="index">
+              {{ weaponNames[weapon.key.c] }}
+            </v-btn>
           </v-btn-toggle>
-        </v-card-actions>
-      </v-layout>
+        </div>
+      </div>
     </v-container>
+    <div></div>
   </v-card>
 </template>
 <script>
@@ -49,18 +39,18 @@ export default {
     return {
       weaponNames: {
         80: "Click", // 80 = char 'P' = 'Play' = Regular move
-        66: "Bomb" // 66 = char 'B' = 'Bomb'
+        66: "Bomb", // 66 = char 'B' = 'Bomb'
       },
-      activeWeaponIndex: 0
+      activeWeaponIndex: 0,
     };
   },
   watch: {
     activeWeaponIndex(value) {
       this.$store.commit("games/selectWeapon", {
         player: this.playerData,
-        selectedWeapon: value
+        selectedWeapon: value,
       });
-    }
+    },
   },
   computed: {
     index() {
@@ -76,7 +66,7 @@ export default {
       userPicture(state) {
         let user = state.onlineUsers[this.name];
         return user ? user.picture : null;
-      }
+      },
     }),
     playerWeapons() {
       return this.playerData.player.weapons.toArray();
@@ -89,8 +79,8 @@ export default {
     },
     score() {
       return this.playerData.player.score;
-    }
-  }
+    },
+  },
 };
 </script>
 <style scoped>
@@ -119,5 +109,10 @@ export default {
   to {
     box-shadow: 0 0 10px 10px #aef4af;
   }
+}
+
+.display-grid {
+  display: grid;
+  grid-template-columns: 60% 40%;
 }
 </style>

--- a/src/views/games/PlayerView.vue
+++ b/src/views/games/PlayerView.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card dark>
+  <v-card dark style="width: 98%">
     <v-container
       fluid
       class="player-view"

--- a/src/views/lobby/IncompleteGame.vue
+++ b/src/views/lobby/IncompleteGame.vue
@@ -1,37 +1,32 @@
 <template>
-  <v-card>
-    <v-layout row wrap align-center justify-center>
-      <v-flex xs6 v-for="(info, index) in playerScores" :key="index">
-        <v-layout
-          column
-          align-center
-          justify-center
-          :class="{ currentPlayer: game.currentPlayerIndex === index }"
-        >
+  <v-card class="px-2" style="text-align: center">
+    <div class="class-grid">
+      <div v-for="(info, index) in playerScores" :key="index">
+        <div :class="{ currentPlayer: game.currentPlayerIndex === index }">
           <img
             style="width: 36px; height: 36px; margin-top: 4px"
             :src="users[index].picture"
             v-if="users[index] && users[index].picture"
           />
           <v-icon large v-else>help</v-icon>
-          <span>{{ info.playerName }}</span>
-          <span>{{ info.score }}</span>
-        </v-layout>
-      </v-flex>
-      <v-flex xs12>
-        <v-tooltip bottom>
-          <template v-slot:activator="{ on }">
-            <v-btn style="align-self: center" @click="resume()" v-on="on">
-              Resume
-            </v-btn>
-          </template>
-          <span>GameId {{ game.gameId }}</span>
-        </v-tooltip>
-        <!--
+          <div>{{ info.playerName }}</div>
+          <div>{{ info.score }}</div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <v-tooltip bottom>
+        <template v-slot:activator="{ on }">
+          <v-btn style="align-self: center" @click="resume()" v-on="on">
+            Resume
+          </v-btn>
+        </template>
+        <span>GameId {{ game.gameId }}</span>
+      </v-tooltip>
+      <!--
           <TimeAgo :timestamp="game.timestamp" />
         -->
-      </v-flex>
-    </v-layout>
+    </div>
   </v-card>
 </template>
 <script>
@@ -43,13 +38,13 @@ export default {
   methods: {
     resume() {
       this.$store.dispatch("games/resume", this.game.gameId);
-    }
+    },
   },
   computed: {
     playerScores() {
       return this.players.map((playerName, index) => ({
         playerName: playerName,
-        score: this.scores[index]
+        score: this.scores[index],
       }));
     },
     players() {
@@ -61,10 +56,17 @@ export default {
     ...mapState("lobby", {
       users(state) {
         return this.playerScores.map(
-          player => state.onlineUsers[player.playerName]
+          (player) => state.onlineUsers[player.playerName]
         );
-      }
-    })
-  }
+      },
+    }),
+  },
 };
 </script>
+
+<style scoped>
+.class-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+</style>

--- a/src/views/lobby/Lobby.vue
+++ b/src/views/lobby/Lobby.vue
@@ -1,52 +1,49 @@
 <template>
-  <v-container fluid>
+  <v-container fluid class="padding-mobile">
     <Invites />
-    <v-layout row wrap align-space-around>
-      <v-flex xs12 lg6>
-        <v-layout row wrap align-space-around>
-          <LobbyBox class="xs12" title="Your Games">
-            <SmallBox
-              class="xs12 md6"
-              v-for="game in incompleteGames"
-              :key="game.gameId"
-            >
-              <IncompleteGame :game="game" />
-            </SmallBox>
-          </LobbyBox>
-
-          <LobbyBox class="xs12" title="Online Players" transition="true">
-            <template v-for="(user, i) in onlineRealUsers">
-              <SmallBox class="xs12 xl6" :key="i">
-                <OnlineUser :user="user" :key="i" :invite="invite" />
-              </SmallBox>
-            </template>
-          </LobbyBox>
-
-          <LobbyBox class="xs12" title="Online AIs">
-            <SmallBox
-              class="xs12 xl6"
-              v-for="user in onlineAIs"
-              :key="user.userName"
-            >
-              <OnlineUser :user="user" :invite="invite" />
-            </SmallBox>
-          </LobbyBox>
-
-          <LobbyBox class="xs12" title="Other Games" transition="true">
-            <template v-for="(game, index) in lobbyGames">
-              <SmallBox class="xs12 md6" :key="index">
-                <LobbyGame :game="game" />
-              </SmallBox>
-            </template>
-          </LobbyBox>
-        </v-layout>
-      </v-flex>
-      <v-flex xs12 lg6>
-        <LobbyBox class="xs12" title="Chat">
-          <Messages @send="sendChat" :messages="messages" />
+    <div class="display-box">
+      <div>
+        <LobbyBox title="Your Games">
+          <div
+            class="incomplete-game"
+            v-for="game in incompleteGames"
+            :key="game.gameId"
+          >
+            <IncompleteGame :game="game" />
+          </div>
         </LobbyBox>
-      </v-flex>
-    </v-layout>
+
+        <LobbyBox title="Online Players" transition="true">
+          <template v-for="(user, i) in onlineRealUsers">
+            <OnlineUser class="pa-2" :user="user" :key="i" :invite="invite" />
+          </template>
+        </LobbyBox>
+
+        <LobbyBox title="Online AIs">
+          <template v-for="user in onlineAIs">
+            <OnlineUser :key="user.userName" :user="user" :invite="invite" />
+          </template>
+        </LobbyBox>
+
+        <LobbyBox title="Other Games" transition="true">
+          <template v-for="(game, index) in lobbyGames">
+            <div :key="index">
+              <LobbyGame :game="game" />
+            </div>
+          </template>
+        </LobbyBox>
+      </div>
+      <div>
+        <v-card>
+          <v-toolbar color="primary" dark>
+            <v-toolbar-title class="headline">
+              <span>Chat</span>
+            </v-toolbar-title>
+          </v-toolbar>
+          <Messages class="pa-2" @send="sendChat" :messages="messages" />
+        </v-card>
+      </div>
+    </div>
   </v-container>
 </template>
 <script>
@@ -55,7 +52,6 @@ import Messages from "./Messages";
 import Invites from "./Invites";
 import IncompleteGame from "./IncompleteGame";
 import LobbyBox from "./LobbyBox";
-import SmallBox from "./SmallBox";
 import LobbyGame from "./LobbyGame";
 import OnlineUser from "./OnlineUser";
 
@@ -66,53 +62,69 @@ export default {
     Invites,
     IncompleteGame,
     LobbyBox,
-    SmallBox,
     LobbyGame,
-    OnlineUser
+    OnlineUser,
   },
   computed: {
     onlineRealUsers() {
       let users = this.onlineUsers;
       return Object.keys(users)
-        .filter(userName => !userName.startsWith("#AI"))
-        .map(key => users[key])
+        .filter((userName) => !userName.startsWith("#AI"))
+        .map((key) => users[key])
         .sort((user1, user2) => user1.rating - user2.rating);
     },
     onlineAIs() {
       let users = this.onlineUsers;
       return Object.keys(users)
-        .filter(userName => userName.startsWith("#AI"))
-        .map(key => users[key])
+        .filter((userName) => userName.startsWith("#AI"))
+        .map((key) => users[key])
         .sort((user1, user2) => user1.rating - user2.rating);
     },
     ...mapState("games", ["incompleteGames"]),
     ...mapGetters("games", ["activeGame"]),
-    ...mapState("lobby", ["messages", "onlineUsers", "lobbyGames"])
+    ...mapState("lobby", ["messages", "onlineUsers", "lobbyGames"]),
   },
   watch: {
     activeGame(value) {
       if (value) {
         this.$router.push("/activeGame");
       }
-    }
+    },
   },
   methods: {
     invite(user) {
       this.$store.dispatch("invites/sendInvite", {
         target: user,
-        plugin: "PluginClassicGame"
+        plugin: "PluginClassicGame",
       });
     },
     sendChat(message) {
       this.$store.dispatch("lobby/sendChat", message);
-    }
-  }
+    },
+  },
 };
 </script>
 <style scoped>
 .small-box {
   transition: all 1.5s;
-  display: inline-block;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+.display-box {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+@media (max-width: 767px) {
+  .padding-mobile {
+    padding: 8px;
+  }
+  .display-box {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
 }
 
 .fade-enter,

--- a/src/views/lobby/Lobby.vue
+++ b/src/views/lobby/Lobby.vue
@@ -6,8 +6,8 @@
         <LobbyBox title="Your Games">
           <div
             class="incomplete-game"
-            v-for="game in incompleteGames"
-            :key="game.gameId"
+            v-for="(game, index) in incompleteGames"
+            :key="index"
           >
             <IncompleteGame :game="game" />
           </div>

--- a/src/views/lobby/LobbyBox.vue
+++ b/src/views/lobby/LobbyBox.vue
@@ -1,32 +1,45 @@
 <template>
-  <v-flex>
-    <v-container fluid grid-list-md>
-      <v-layout column>
-        <v-card xs12 lg6>
-          <v-toolbar color="primary" dark>
-            <v-toolbar-title class="headline">
-              <span>{{ title }}</span>
-            </v-toolbar-title>
-          </v-toolbar>
-          <transition-group
-            v-if="transition"
-            name="fade"
-            tag="div"
-            class="layout row wrap transition-tool"
-          >
-            <slot></slot>
-          </transition-group>
-          <v-layout v-else row wrap>
-            <slot></slot>
-          </v-layout>
-        </v-card>
-      </v-layout>
-    </v-container>
-  </v-flex>
+  <v-card class="mb-4">
+    <v-toolbar color="primary" dark>
+      <v-toolbar-title class="headline">
+        <span>{{ title }}</span>
+      </v-toolbar-title>
+    </v-toolbar>
+    <transition-group
+      v-if="transition"
+      name="fade"
+      tag="div"
+      class="class-grid"
+    >
+      <slot></slot>
+    </transition-group>
+    <div v-else class="class-grid">
+      <slot></slot>
+    </div>
+  </v-card>
 </template>
+
 <script>
 export default {
   name: "LobbyBox",
-  props: ["title", "transition"]
+  props: ["title", "transition"],
 };
 </script>
+
+<style scoped>
+.class-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  padding: 10px;
+}
+
+@media (max-width: 767px) {
+  .class-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 10px;
+    padding: 10px;
+  }
+}
+</style>

--- a/src/views/lobby/Messages.vue
+++ b/src/views/lobby/Messages.vue
@@ -8,9 +8,9 @@
       <template v-for="(item, index) in messages">
         <div
           :key="index"
-          :class="!singleElement ? 'class-left' : 'class-right'"
+          :class="!checkYourUser(item) ? 'class-left' : 'class-right'"
         >
-          <div v-if="!singleElement">
+          <div v-if="!checkYourUser(item)">
             <b>{{ breakMessage(item.message).player }}</b>
             <div
               class="class-message"
@@ -26,9 +26,7 @@
             <b>{{ breakMessage(item.message).player }}</b>
             <div
               class="class-message"
-              :class="
-                theme === 'dark' ? 'dark-enemy black--text' : 'light-enemy'
-              "
+              :class="theme === 'dark' ? 'dark-enemy' : 'light-enemy'"
             >
               <span> {{ breakMessage(item.message).message }}</span>
             </div>
@@ -52,11 +50,12 @@
     <v-btn block @click="sendMessage">Send</v-btn>
   </div>
 </template>
+
 <script>
 import { mapState } from "vuex";
 export default {
   name: "Messages",
-  props: ["messages", "singleElement"],
+  props: ["messages"],
   data() {
     return { message: "" };
   },
@@ -85,6 +84,10 @@ export default {
     }),
   },
   methods: {
+    checkYourUser(item) {
+      const checkYourName = this.$store.state.socket.loggedIn;
+      return checkYourName === this.breakMessage(item.message).player;
+    },
     breakMessage(item) {
       const colonIndex = item.indexOf(":");
       if (colonIndex !== -1) {
@@ -117,7 +120,6 @@ export default {
   height: 450px;
   line-height: 1.6;
   width: 100%;
-  /* border: 4px solid blue; */
   word-break: break-all;
   padding: 12px;
   margin-bottom: 12px;
@@ -143,8 +145,8 @@ export default {
 }
 
 .dark-player {
-  background: #1c85fe;
-  color: white;
+  background: #e0e0e0;
+  color: black;
 }
 
 .light-enemy {
@@ -153,7 +155,7 @@ export default {
 }
 
 .dark-enemy {
-  background: #e0e0e0;
+  background: #1c85fe;
 }
 
 .class-right {

--- a/src/views/lobby/Messages.vue
+++ b/src/views/lobby/Messages.vue
@@ -1,35 +1,50 @@
 <template>
   <div>
-    <v-container
-      ref="container"
-      grid-list-md
-      text-xs-left
-      fluid
-      class="messages"
-    >
-      <v-layout id="message-content" row wrap>
-        <template v-for="(item, index) in messages">
-          <div v-if="singleElement">
-            [{{ item.timestamp }}] {{ item.message }}
+    <v-container ref="container" class="messages">
+      <template v-for="(item, index) in messages">
+        <div
+          :key="index"
+          :class="!singleElement ? 'class-left' : 'class-right'"
+        >
+          <div
+            v-if="!singleElement"
+            class="class-message"
+            :class="theme === 'dark' ? 'dark-player' : 'light-player'"
+          >
+            <div>
+              <span style="font-size: 12px">[{{ item.timestamp }}]</span>
+              <span> {{ breakMessage(item.message).player }}:</span>
+            </div>
+            <div>
+              <b>{{ breakMessage(item.message).message }}</b>
+            </div>
           </div>
-          <template v-else>
-            <v-flex xs4 lg2 :key="'time-' + index">
-              {{ item.timestamp }}
-            </v-flex>
-            <v-flex xs8 lg10 :key="'message-' + index">
-              {{ item.message }}
-            </v-flex>
-          </template>
-        </template>
-      </v-layout>
+          <div
+            v-else
+            class="class-message"
+            :class="theme === 'dark' ? 'dark-enemy' : 'light-enemy'"
+          >
+            <div>
+              <span style="font-size: 12px">[{{ item.timestamp }}]</span>
+              <span> {{ breakMessage(item.message).player }}:</span>
+            </div>
+            <div>
+              <b>{{ breakMessage(item.message).message }}</b>
+            </div>
+          </div>
+        </div>
+      </template>
     </v-container>
-    <v-text-field
-      class="message-input"
-      label="Message"
+
+    <v-textarea
+      class="message-input pa-2"
+      label="Write a message"
       v-model="message"
-      placeholder="Write a message"
       @keyup.native.enter="sendMessage"
-    ></v-text-field>
+      style="color: white"
+      :style="theme === 'dark' ? 'background: #546e7a' : 'background: #1e88e5'"
+      hide-details
+    ></v-textarea>
     <v-btn @click="sendMessage">Send</v-btn>
   </div>
 </template>
@@ -46,9 +61,29 @@ export default {
   watch: {
     messages() {
       this.scrollToBottom();
-    }
+    },
+  },
+  computed: {
+    theme: {
+      get() {
+        return this.$store.state.settings.theme;
+      },
+      set(value) {
+        this.$store.commit("settings/setTheme", value);
+      },
+    },
   },
   methods: {
+    breakMessage(item) {
+      const colonIndex = item.indexOf(":");
+      if (colonIndex !== -1) {
+        const player = item.substring(0, colonIndex).trim();
+        const message = item.substring(colonIndex + 1).trim();
+        return { player: player, message: message };
+      } else {
+        console.log("Invalid message");
+      }
+    },
     scrollToBottom() {
       this.$nextTick(() => {
         let container = this.$refs.container;
@@ -61,19 +96,71 @@ export default {
       }
       this.$emit("send", this.message);
       this.message = "";
-    }
-  }
+    },
+  },
 };
 </script>
 <style scoped>
 .messages {
-  height: 600px;
-  overflow-y: scroll;
-  overflow-x: hidden;
-  margin-left: -5px;
+  overflow-y: auto;
+  height: 450px;
+  line-height: 1.6;
+  width: 100%;
+  border: 4px solid blue;
+  word-break: break-all;
+  padding: 12px;
+  margin-bottom: 12px;
 }
-.message-input {
-  margin-left: 15px;
-  margin-right: 15px;
+
+::v-deep ::-webkit-scrollbar {
+  background: green;
+  width: 0.4rem;
+}
+
+::v-deep ::-webkit-scrollbar-thumb {
+  background: #cfd9e3;
+  border-radius: 1rem;
+}
+
+::v-deep ::-webkit-scrollbar-track {
+  height: 30rem !important;
+}
+
+.light-player {
+  background: #1e88e5;
+  color: white;
+}
+
+.dark-player {
+  background: #1e88e5;
+}
+
+.light-enemy {
+  background: #90a4ae;
+  /* color: white; */
+}
+
+.dark-enemy {
+  background: #546e7a;
+}
+
+.class-right {
+  text-align: -webkit-right;
+}
+
+.class-message {
+  width: 80%;
+  margin: 6px 0;
+  padding: 8px;
+  border-radius: 16px;
+  text-align: start;
+}
+
+::v-deep .v-label {
+  color: #fff;
+}
+
+::v-deep .v-text-field__slot textarea {
+  color: #fff !important;
 }
 </style>

--- a/src/views/lobby/Messages.vue
+++ b/src/views/lobby/Messages.vue
@@ -1,35 +1,39 @@
 <template>
   <div>
-    <v-container ref="container" class="messages">
+    <v-container
+      ref="container"
+      class="messages"
+      :style="theme === 'dark' ? 'background: #37474F' : 'background: #e0e0e0'"
+    >
       <template v-for="(item, index) in messages">
         <div
           :key="index"
           :class="!singleElement ? 'class-left' : 'class-right'"
         >
-          <div
-            v-if="!singleElement"
-            class="class-message"
-            :class="theme === 'dark' ? 'dark-player' : 'light-player'"
-          >
-            <div>
-              <span style="font-size: 12px">[{{ item.timestamp }}]</span>
-              <span> {{ breakMessage(item.message).player }}:</span>
+          <div v-if="!singleElement">
+            <b>{{ breakMessage(item.message).player }}</b>
+            <div
+              class="class-message"
+              :class="theme === 'dark' ? 'dark-player' : 'light-player'"
+            >
+              <span> {{ breakMessage(item.message).message }}</span>
             </div>
-            <div>
-              <b>{{ breakMessage(item.message).message }}</b>
+            <div style="font-size: 12px">
+              {{ item.timestamp.split(",")[1] }}
             </div>
           </div>
-          <div
-            v-else
-            class="class-message"
-            :class="theme === 'dark' ? 'dark-enemy' : 'light-enemy'"
-          >
-            <div>
-              <span style="font-size: 12px">[{{ item.timestamp }}]</span>
-              <span> {{ breakMessage(item.message).player }}:</span>
+          <div v-else>
+            <b>{{ breakMessage(item.message).player }}</b>
+            <div
+              class="class-message"
+              :class="
+                theme === 'dark' ? 'dark-enemy black--text' : 'light-enemy'
+              "
+            >
+              <span> {{ breakMessage(item.message).message }}</span>
             </div>
-            <div>
-              <b>{{ breakMessage(item.message).message }}</b>
+            <div style="font-size: 12px">
+              {{ item.timestamp.split(",")[1] }}
             </div>
           </div>
         </div>
@@ -37,18 +41,19 @@
     </v-container>
 
     <v-textarea
-      class="message-input pa-2"
+      class="pa-1"
       label="Write a message"
       v-model="message"
       @keyup.native.enter="sendMessage"
-      style="color: white"
-      :style="theme === 'dark' ? 'background: #546e7a' : 'background: #1e88e5'"
+      style="color: black"
+      :style="theme === 'dark' ? 'background: #37474F' : 'background: #E0E0E0'"
       hide-details
     ></v-textarea>
-    <v-btn @click="sendMessage">Send</v-btn>
+    <v-btn block @click="sendMessage">Send</v-btn>
   </div>
 </template>
 <script>
+import { mapState } from "vuex";
 export default {
   name: "Messages",
   props: ["messages", "singleElement"],
@@ -72,6 +77,12 @@ export default {
         this.$store.commit("settings/setTheme", value);
       },
     },
+    ...mapState("lobby", {
+      userPicture(state) {
+        let user = state.onlineUsers[this.name];
+        return user ? user.picture : null;
+      },
+    }),
   },
   methods: {
     breakMessage(item) {
@@ -106,7 +117,7 @@ export default {
   height: 450px;
   line-height: 1.6;
   width: 100%;
-  border: 4px solid blue;
+  /* border: 4px solid blue; */
   word-break: break-all;
   padding: 12px;
   margin-bottom: 12px;
@@ -127,21 +138,22 @@ export default {
 }
 
 .light-player {
-  background: #1e88e5;
-  color: white;
+  background: #fff;
+  color: black;
 }
 
 .dark-player {
-  background: #1e88e5;
+  background: #1c85fe;
+  color: white;
 }
 
 .light-enemy {
-  background: #90a4ae;
-  /* color: white; */
+  background: #1c85fe;
+  color: white;
 }
 
 .dark-enemy {
-  background: #546e7a;
+  background: #e0e0e0;
 }
 
 .class-right {
@@ -149,18 +161,13 @@ export default {
 }
 
 .class-message {
-  width: 80%;
-  margin: 6px 0;
+  width: fit-content;
   padding: 8px;
   border-radius: 16px;
   text-align: start;
 }
 
-::v-deep .v-label {
-  color: #fff;
-}
-
-::v-deep .v-text-field__slot textarea {
-  color: #fff !important;
-}
+/* ::v-deep .v-label {
+  color: black;
+} */
 </style>

--- a/src/views/lobby/OnlineUser.vue
+++ b/src/views/lobby/OnlineUser.vue
@@ -1,28 +1,24 @@
 <template>
   <v-card>
-    <v-layout row justify-center align-center class="online-user">
-      <v-list-tile class="grow">
-        <v-list-tile-avatar>
-          <img :src="user.picture" v-if="user.picture" />
-          <v-icon large v-else>help</v-icon>
-        </v-list-tile-avatar>
-        <v-list-tile-content>
-          <span>{{ user.userName }}</span>
-        </v-list-tile-content>
-        <v-layout align-center justify-end fill-height>
-          <v-tooltip left v-if="ratingFeature">
-            <template v-slot:activator="{ on }">
-              <v-icon>show_chart</v-icon>
-              <span class="subheading mr-2">{{ user.rating }}</span>
-            </template>
-            <span>Rating</span>
-          </v-tooltip>
-          <v-btn @click="invite(user)" v-if="user.userName !== loggedIn"
-            >Challenge</v-btn
-          >
-        </v-layout>
-      </v-list-tile>
-    </v-layout>
+    <v-list-tile>
+      <v-list-tile-avatar>
+        <img :src="user.picture" v-if="user.picture" />
+        <v-icon large v-else>help</v-icon>
+      </v-list-tile-avatar>
+      <v-list-tile-content>
+        <span>{{ user.userName }}</span>
+      </v-list-tile-content>
+      <v-tooltip left v-if="ratingFeature">
+        <template v-slot:activator="{ on }">
+          <v-icon>show_chart</v-icon>
+          <span class="subheading mr-2">{{ user.rating }}</span>
+        </template>
+        <span>Rating</span>
+      </v-tooltip>
+      <v-btn @click="invite(user)" v-if="user.userName !== loggedIn"
+        >Challenge
+      </v-btn>
+    </v-list-tile>
   </v-card>
 </template>
 <script>
@@ -35,7 +31,15 @@ export default {
     ratingFeature() {
       return process.env.VUE_APP_FEATURE_RATING;
     },
-    ...mapState("socket", ["loggedIn"])
-  }
+    ...mapState("socket", ["loggedIn"]),
+  },
 };
 </script>
+
+<style scoped>
+@media (max-width: 767px) {
+  ::v-deep .v-list__tile {
+    padding: 0 4px;
+  }
+}
+</style>


### PR DESCRIPTION
- [x] Border-radius has a too thick thickness, making it difficult to read the block number.
- [x] The game's width could be between 90% and 100%.
- [x] Chat: Maybe could use v-lazy or v-textarea.
- [x] Improve the visualization of v-card where there is a nickname, points, blick|bomb.

![image](https://github.com/Zomis/minesweeper-flags-client/assets/79769515/79d1c24c-51b9-4f21-ad6f-453546b27ed2)
![image](https://github.com/Zomis/minesweeper-flags-client/assets/79769515/9a2173cc-c081-40a8-85bd-0cbf41c6d7e3)
![image](https://github.com/Zomis/minesweeper-flags-client/assets/79769515/e70c3adf-06f4-49d3-a391-bdcf9257d311)
![image](https://github.com/Zomis/minesweeper-flags-client/assets/79769515/cd28e48e-b1bd-4530-ab19-fc219b00e8a7)

Closes #55 